### PR TITLE
Remove hardcoded env file from the start parameter.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Deva Kumaraswamy <deva.kumar@sas.com>",
   "license": "SEE LICENSE IN LICENSE",
   "scripts": {
-    "start": "node index.js uidemos.env",
+    "start": "node index.js",
     "proxy": "node index.js",
     "postinstall": "node copy.js"
   },


### PR DESCRIPTION
Without removing this, it's not possible to start the application using the instructions in the readme.